### PR TITLE
[feat] Add --force flag

### DIFF
--- a/repobee_sanitizer/_sanitize_repo.py
+++ b/repobee_sanitizer/_sanitize_repo.py
@@ -34,14 +34,11 @@ class SanitizeRepo(plug.Plugin):
         if not args.file_list.is_file():
             raise plug.PlugError(f"No such file: {args.file_list}")
 
-        if not args.force:
-            message = _check_repo_state(args.repo_root)
-            if message:
-                return plug.Result(
-                    name="sanitize-repo",
-                    msg=message,
-                    status=plug.Status.ERROR,
-                )
+        message = _check_repo_state(args.repo_root)
+        if message and not args.force:
+            return plug.Result(
+                name="sanitize-repo", msg=message, status=plug.Status.ERROR,
+            )
 
         file_relpaths = [
             p.strip()

--- a/repobee_sanitizer/_sanitize_repo.py
+++ b/repobee_sanitizer/_sanitize_repo.py
@@ -56,13 +56,6 @@ class SanitizeRepo(plug.Plugin):
                 args.repo_root, file_relpaths, args.target_branch
             )
 
-        if args.force:
-            return plug.Result(
-                name="sanitize-repo",
-                msg="Sanitize-repo was forced",
-                status=plug.Status.SUCCESS,
-            )
-
     def create_extension_command(self) -> plug.ExtensionCommand:
         """
         Returns:

--- a/repobee_sanitizer/_sanitize_repo.py
+++ b/repobee_sanitizer/_sanitize_repo.py
@@ -137,6 +137,7 @@ def _sanitize_to_target_branch(
     with tempfile.TemporaryDirectory() as tmpdir:
         repo_copy_path = pathlib.Path(tmpdir) / "repo"
         shutil.copytree(src=repo_path, dst=repo_copy_path)
+        _clean_repo(repo_copy_path)
         _sanitize_files(repo_copy_path, file_relpaths)
         _git_commit_on_branch(repo_copy_path, target_branch)
         _git_fetch(
@@ -145,6 +146,15 @@ def _sanitize_to_target_branch(
             dst_repo_path=repo_path,
             dst_branch=target_branch,
         )
+
+
+def _clean_repo(repo_path: pathlib.Path):
+    """Resets working tree and index to HEAD. This is to untracked files as
+    well as uncommitted changes.
+    """
+    repo = git.Repo(str(repo_path))
+    repo.git.reset("--hard")
+    repo.git.clean("-dfx")
 
 
 def _check_repo_state(repo_root) -> Optional[str]:

--- a/tests/test_ext_commands.py
+++ b/tests/test_ext_commands.py
@@ -193,6 +193,13 @@ def test_sanitize_repo_passes_with_force_flag(sanitizer_config, fake_repo):
     untracked_file = fake_repo.path / "untracked.txt"
     untracked_file.write_text("This is some untracked text")
 
+    unstaged_file = fake_repo.file_infos[0].abspath
+    unstaged_file.write_text("This is some new text!")
+
+    tracked_file = fake_repo.file_infos[0].abspath
+    tracked_file.write_text("this is the new text!")
+    fake_repo.repo.git.add(tracked_file)
+
     result = execute_sanitize_repo(
         f"--file-list {fake_repo.file_list_path} "
         f"--repo-root {fake_repo.path} "

--- a/tests/test_ext_commands.py
+++ b/tests/test_ext_commands.py
@@ -187,6 +187,23 @@ def test_sanitize_repo_return_fail_when_has_untracked_files(
     assert "untracked file" in result.msg
 
 
+def test_sanitize_repo_passes_with_force_flag(sanitizer_config, fake_repo):
+    """Test adds an utracked file to make sure that repobee does not complain
+        when we add --force to the command. Expects success status."""
+    untracked_file = fake_repo.path / "untracked.txt"
+    untracked_file.write_text("This is some untracked text")
+
+    result = execute_sanitize_repo(
+        f"--file-list {fake_repo.file_list_path} "
+        f"--repo-root {fake_repo.path} "
+        "--no-commit "
+        "--force"
+    )
+
+    assert result.status == plug.Status.SUCCESS
+    assert "force" in result.msg
+
+
 def execute_sanitize_repo(arguments: str):
     """Run the sanitize-repo function with the given arguments"""
     sanitize_repo = sanitizer.SanitizeRepo()

--- a/tests/test_ext_commands.py
+++ b/tests/test_ext_commands.py
@@ -188,27 +188,44 @@ def test_sanitize_repo_return_fail_when_has_untracked_files(
 
 
 def test_sanitize_repo_passes_with_force_flag(sanitizer_config, fake_repo):
-    """Test adds an utracked file to make sure that repobee does not complain
-        when we add --force to the command. Expects success status."""
+    """Test adds an utracked, unstaged, and staged file to make sure
+    that repobee does not complain when we add --force to the command.
+    Expects these files to NOT exist on target branch, as only
+    committed changes should be sanitized.
+    """
+    untracked_file_content = "This is some untracked text"
     untracked_file = fake_repo.path / "untracked.txt"
-    untracked_file.write_text("This is some untracked text")
+    untracked_file.write_text(untracked_file_content)
 
+    unstaged_file_content = "This is some unstaged text!"
     unstaged_file = fake_repo.file_infos[0].abspath
-    unstaged_file.write_text("This is some new text!")
+    unstaged_file.write_text(unstaged_file_content)
 
-    tracked_file = fake_repo.file_infos[0].abspath
-    tracked_file.write_text("this is the new text!")
-    fake_repo.repo.git.add(tracked_file)
+    staged_file_content = "This file is staged!"
+    staged_file = fake_repo.file_infos[1].abspath
+    staged_file.write_text(staged_file_content)
+    fake_repo.repo.git.add(staged_file)
 
-    result = execute_sanitize_repo(
+    target_branch = "student-version"
+
+    execute_sanitize_repo(
         f"--file-list {fake_repo.file_list_path} "
         f"--repo-root {fake_repo.path} "
-        "--no-commit "
+        f"--target-branch {target_branch} "
         "--force"
     )
 
-    assert result.status == plug.Status.SUCCESS
-    assert "force" in result.msg
+    # Assert that working tree has not been modified
+    assert untracked_file.is_file()
+    assert unstaged_file.read_text() == unstaged_file_content
+    assert staged_file.read_text() == staged_file_content
+
+    fake_repo.repo.git.reset("--hard")
+    fake_repo.repo.git.clean("-dfx")
+
+    fake_repo.repo.git.checkout(target_branch)
+    assert not untracked_file.is_file()
+    assert_expected_text_in_files(fake_repo.file_infos)
 
 
 def test_sanitize_repo_raises_plug_error_if_file_list_doesnt_exist(

--- a/tests/test_ext_commands.py
+++ b/tests/test_ext_commands.py
@@ -203,6 +203,7 @@ def test_sanitize_repo_passes_with_force_flag(sanitizer_config, fake_repo):
     assert result.status == plug.Status.SUCCESS
     assert "force" in result.msg
 
+
 def test_sanitize_repo_raises_plug_error_if_file_list_doesnt_exist(
     sanitizer_config, fake_repo
 ):


### PR DESCRIPTION
Without the --force flag, sanitize-repo will complain if there are untracked or uncommitted tracked files in the repo

Fix #31 