### PR TITLE
[feat] Make sanitizer yell if there are not markers in input

### DIFF
--- a/repobee_sanitizer/_sanitize.py
+++ b/repobee_sanitizer/_sanitize.py
@@ -32,8 +32,10 @@ def _check_syntax(lines: List[str]) -> None:
     last = END_BLOCK
     errors = []
     prefix = ""
+    has_blocks = False
     for line_number, line in enumerate(lines, start=1):
         if START_BLOCK in line:
+            has_blocks = True
             if last != END_BLOCK:
                 errors.append(
                     f"Line {line_number}: "
@@ -63,6 +65,9 @@ def _check_syntax(lines: List[str]) -> None:
 
     if last != END_BLOCK:
         errors.append("Final block must be an END block")
+
+    if not has_blocks:
+        errors.append("There are no markers in the file")
 
     if errors:
         raise plug.PlugError(errors)

--- a/tests/test_case_files/invalid/no-markers.in
+++ b/tests/test_case_files/invalid/no-markers.in
@@ -1,0 +1,18 @@
+class StackTest {
+    @Test
+    public void topIsLastPushedValue() {
+        // Arrange
+        int value = 1338;
+
+        // Act
+        emptyStack.push(value);
+        stack.push(value);
+
+        int emptyStackTop = emptyStack.top();
+        int stackTop = stack.top();
+
+        // Assert
+        assertThat(emptyStackTop, equalTo(value));
+        assertThat(stackTop, equalTo(value));
+    }
+}


### PR DESCRIPTION
Now, if you try to sanitize a file with no markers, the program will yell that there are no markers in it.

Fix #17 