### PR TITLE
[test] Run codecov upload only for Python 3.6

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,6 +43,7 @@ jobs:
       run: |
         pytest -vv --cov=repobee_sanitizer --cov-branch tests/ --cov-report xml
     - name: Upload coverage to Codecov
+      if: matrix.python-version == "3.6"
       uses: codecov/codecov-action@v1
       with:
           fail_ci_if_error: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         pytest -vv --cov=repobee_sanitizer --cov-branch tests/ --cov-report xml
     - name: Upload coverage to Codecov
-      if: ${{ matrix.python-version }} == "3.6"
+      if: ${{ matrix.python-version == "3.6" }}
       uses: codecov/codecov-action@v1
       with:
           fail_ci_if_error: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         pytest -vv --cov=repobee_sanitizer --cov-branch tests/ --cov-report xml
     - name: Upload coverage to Codecov
-      if: matrix.python-version == "3.6"
+      if: ${{ matrix.python-version }} == "3.6"
       uses: codecov/codecov-action@v1
       with:
           fail_ci_if_error: true

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         pytest -vv --cov=repobee_sanitizer --cov-branch tests/ --cov-report xml
     - name: Upload coverage to Codecov
-      if: ${{ matrix.python-version == "3.6" }}
+      if: ${{ matrix.python-version == 3.6 }}
       uses: codecov/codecov-action@v1
       with:
           fail_ci_if_error: true


### PR DESCRIPTION
Fix #49 

Upload to Codecov only with the Python 3.6 run to attempt to fix the intermittent timeouts in uploading.