### PR TITLE
[test] Enable ISO8859 test case

### DIFF
--- a/repobee_sanitizer/_fileutils.py
+++ b/repobee_sanitizer/_fileutils.py
@@ -83,7 +83,5 @@ def guess_encoding(path: pathlib.Path) -> str:
         ["file", "--mime-encoding", "--brief", str(path)],
         stdout=subprocess.PIPE,
     )
-    result = proc.stdout.decode(encoding=sys.getdefaultencoding()).strip()
-    if result.lower() in ["iso8859", "iso-8859"]:
-        result += "-1"
-    return result
+
+    return proc.stdout.decode(encoding=sys.getdefaultencoding()).strip()

--- a/repobee_sanitizer/_fileutils.py
+++ b/repobee_sanitizer/_fileutils.py
@@ -83,4 +83,7 @@ def guess_encoding(path: pathlib.Path) -> str:
         ["file", "--mime-encoding", "--brief", str(path)],
         stdout=subprocess.PIPE,
     )
-    return proc.stdout.decode(encoding=sys.getdefaultencoding()).strip()
+    result = proc.stdout.decode(encoding=sys.getdefaultencoding()).strip()
+    if result == "ISO8859":
+        result += "-1"
+    return result

--- a/repobee_sanitizer/_fileutils.py
+++ b/repobee_sanitizer/_fileutils.py
@@ -84,6 +84,6 @@ def guess_encoding(path: pathlib.Path) -> str:
         stdout=subprocess.PIPE,
     )
     result = proc.stdout.decode(encoding=sys.getdefaultencoding()).strip()
-    if result == "ISO8859":
+    if result.lower() in ["iso8859", "iso-8859"]:
         result += "-1"
     return result

--- a/tests/test_fileutils.py
+++ b/tests/test_fileutils.py
@@ -52,11 +52,6 @@ class TestCreateRelativePath:
 class TestRelativePath:
     """Tests for the RelativePath class."""
 
-    @pytest.mark.xfail(
-        reason="The file command doesn't give the entire ISO8859 encoding "
-        "(e.g. ISO8859-1), so reading crashes",
-        strict=True,
-    )
     def test_read_iso8859_1_encoded_file(self):
         """Currently, guessing ISO8859 encodings with the file command often
         only gives ``ISO8859``, which is not a complete encoding (i.e. it
@@ -70,4 +65,4 @@ class TestRelativePath:
 
         relpath = _fileutils.create_relpath(abspath=abspath, basedir=basedir)
 
-        assert relpath.read_text_relative_to(basedir) == expected_text
+        assert relpath.read_text_relative_to(basedir).strip() == expected_text


### PR DESCRIPTION
Fix #64 

Added a simple append to make the encoding `ISO8859-1` If it was `ISO8859` before

Edit: Turns out this was not a bug in how we fetch the encoding of a file. Instead, this was an unrelated bug combined with the confusion that we  **though** the `file` terminal command gave us the result ISO8859 when we wanted ISO8859-1, 