### PR TITLE
[fact] Use contained_marker throughout project

### DIFF
--- a/repobee_sanitizer/_sanitize.py
+++ b/repobee_sanitizer/_sanitize.py
@@ -6,6 +6,7 @@
 import pathlib
 
 from repobee_sanitizer import _syntax
+from repobee_sanitizer._syntax import Markers
 
 import re
 from typing import List, Iterable, Optional
@@ -26,7 +27,7 @@ def sanitize_file(file_abs_path: pathlib.Path) -> Optional[str]:
     text = file_abs_path.read_text()
     lines = text.split("\n")
     _syntax.check_syntax(lines)
-    if _syntax.contained_marker(lines[0]) == _syntax.Markers.SHRED:
+    if _syntax.contained_marker(lines[0]) == Markers.SHRED:
         file_abs_path.unlink()
     else:
         sanitized_string = _sanitize(lines)
@@ -50,14 +51,12 @@ def _sanitize(lines: List[str]) -> Iterable[str]:
     prefix_length = 0
     for line in lines:
         marker = _syntax.contained_marker(line)
-        if marker == _syntax.Markers.START:
-            prefix = re.match(
-                rf"(.*?){_syntax.Markers.START.value}", line
-            ).group(1)
+        if marker == Markers.START:
+            prefix = re.match(rf"(.*?){Markers.START.value}", line).group(1)
             prefix_length = len(prefix)
             keep = False
-        elif marker in [_syntax.Markers.REPLACE, _syntax.Markers.END]:
-            if marker == _syntax.Markers.END:
+        elif marker in [Markers.REPLACE, Markers.END]:
+            if marker == Markers.END:
                 prefix_length = 0
             keep = True
             continue

--- a/repobee_sanitizer/_sanitize.py
+++ b/repobee_sanitizer/_sanitize.py
@@ -26,7 +26,7 @@ def sanitize_file(file_abs_path: pathlib.Path) -> Optional[str]:
     text = file_abs_path.read_text()
     lines = text.split("\n")
     _syntax.check_syntax(lines)
-    if _syntax.Markers.SHRED.value in lines[0]:
+    if _syntax.contained_marker(lines[0]) == _syntax.Markers.SHRED:
         file_abs_path.unlink()
     else:
         sanitized_string = _sanitize(lines)
@@ -49,17 +49,15 @@ def _sanitize(lines: List[str]) -> Iterable[str]:
     keep = True
     prefix_length = 0
     for line in lines:
-        if _syntax.Markers.START.value in line:
+        marker = _syntax.contained_marker(line)
+        if marker == _syntax.Markers.START:
             prefix = re.match(
                 rf"(.*?){_syntax.Markers.START.value}", line
             ).group(1)
             prefix_length = len(prefix)
             keep = False
-        elif (
-            _syntax.Markers.REPLACE.value in line
-            or _syntax.Markers.END.value in line
-        ):
-            if _syntax.Markers.END.value in line:
+        elif marker in [_syntax.Markers.REPLACE, _syntax.Markers.END]:
+            if marker == _syntax.Markers.END:
                 prefix_length = 0
             keep = True
             continue


### PR DESCRIPTION
Fix #82 

This makes `_syntax._contained_marker` public and uses it throughout the project. It cleans up the code significantly and makes it possible to use the `Markers` enum without accessing the `.value` attribute.