### PR TITLE
[fix] Fix error when Check syntax is given an empty list

### DIFF
--- a/repobee_sanitizer/_syntax.py
+++ b/repobee_sanitizer/_syntax.py
@@ -66,7 +66,7 @@ def check_syntax(lines: List[str]) -> None:
     """
     last = Markers.END
     prefix = ""
-    has_blocks = contained_marker(lines[0]) == Markers.SHRED
+    has_blocks = lines and contained_marker(lines[0]) == Markers.SHRED
 
     errors = _check_shred_syntax(lines)
     if errors:

--- a/tests/test_case_files/test_syntax.py
+++ b/tests/test_case_files/test_syntax.py
@@ -1,0 +1,14 @@
+import pytest
+
+from repobee_sanitizer import _syntax
+import repobee_plug as plug
+
+
+def test_check_syntax_with_empty_string():
+    """Check_syntax is a public function, therefore we have to check what
+    happens if we give it an empty string.
+    """
+    with pytest.raises(plug.PlugError) as exc:
+        _syntax.check_syntax("")
+
+    assert "There are no markers in the file" in exc.value

--- a/tests/test_case_files/test_syntax.py
+++ b/tests/test_case_files/test_syntax.py
@@ -6,7 +6,8 @@ import repobee_plug as plug
 
 def test_check_syntax_with_empty_string():
     """Check_syntax is a public function, therefore we have to check what
-    happens if we give it an empty string.
+    happens if we give it an empty string. If it returns a PlugError, we have
+    the proper behavior.
     """
     with pytest.raises(plug.PlugError) as exc:
         _syntax.check_syntax("")

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -9,7 +9,7 @@ def test_check_syntax_with_empty_string():
     happens if we give it an empty string. If it returns a PlugError, we have
     the proper behavior.
     """
-    with pytest.raises(plug.PlugError) as exc:
+    with pytest.raises(plug.PlugError) as exc_info:
         _syntax.check_syntax("")
 
-    assert "There are no markers in the file" in str(exc.value)
+    assert "There are no markers in the file" in str(exc_info.value)

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -12,4 +12,4 @@ def test_check_syntax_with_empty_string():
     with pytest.raises(plug.PlugError) as exc:
         _syntax.check_syntax("")
 
-    assert "There are no markers in the file" in exc.value
+    assert "There are no markers in the file" in str(exc.value)


### PR DESCRIPTION
Added an invalid test case file to check implementation as well as a test to make sure that check_syntax does not crash if we give it an empty list

Fix #75

