### PR TITLE
[docs] Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ similar preceding our markers. **This means code can still compile!**
     prefixes
 * Code between replace and end markers **MUST** also be prefixed
 
-## Markup syntax
+## Syntax
 
-for `repobee-sanitizer` to work, markup syntax must be correct, this includes
+for `repobee-sanitizer` to work, marker syntax must be correct, this includes
 spelling of the markers themselves, the markers currently are as follows:
 
 - REPOBEE-SANITIZER-START

--- a/README.md
+++ b/README.md
@@ -7,11 +7,16 @@
 
 # repobee-sanitizer
 
-A plugin for RepoBee to sanitize template repositories before being pushed to students.
-`repobee-sanitizer` adds the commands `sanitize-file` and `sanitize-repo` that lets the user sanitize files and repos (directories currently) respectively.
-`repobee-sanitizer` can remove or replace text by going through files, looking for certain `REPOBEE-SANITIZER-<type>` text-markers. The most simple usage consists of a `REPOBEE-SANITIZER-START` and a `REPOBEE-SANITIZER-END` marker, where content between these two markers will be removes, or "santitized".
+A plugin for RepoBee to sanitize template repositories before being pushed to
+students.  `repobee-sanitizer` adds the commands `sanitize-file` and
+`sanitize-repo` that lets the user sanitize files and repos (directories
+currently) respectively.  `repobee-sanitizer` can remove or replace text by
+going through files, looking for certain `REPOBEE-SANITIZER-<type>`
+text-markers. The most simple usage consists of a `REPOBEE-SANITIZER-START` and
+a `REPOBEE-SANITIZER-END` marker, where content between these two markers will
+be removes, or "santitized".
 
-# Example use cases
+## Example use cases
 
 Consider the following code:
 
@@ -40,7 +45,9 @@ REPOBEE-SANITIZER-END
 
 >Example 1: The simplest usage of `repobee-sanitizer` using a .java file
 
-For this .java test file, the `santize-file` command will identify the START and END markers, and proceed to remove the code inbetween. The result will look like this:
+For this .java test file, the `santize-file` command will identify the START
+and END markers, and proceed to remove the code inbetween. The result will look
+like this:
 
 ```java
 class StackTest {
@@ -50,9 +57,11 @@ class StackTest {
 }
 ```
 
-`repobee-sanitizer` also supports the `REPOBEE-SANITIZER-REPLACE-WITH` marker. By adding a replace marker, we can specify code that should replace the removed code. Example as follows:
+`repobee-sanitizer` also supports the `REPOBEE-SANITIZER-REPLACE-WITH` marker.
+By adding a replace marker, we can specify code that should replace the removed
+code. Example as follows:
 
-````java
+```java
 class StackTest {
     @Test
     public void topIsLastPushedValue() {
@@ -75,30 +84,42 @@ REPOBEE-SANITIZER-REPLACE-WITH
 REPOBEE-SANITIZER-END
     }
 }
-````
+```
 
-> Example 2: The code is the same as for example 1, but we have added a `REPOBEE-SANITIZER-REPLACE-WITH` marker.
+> Example 2: The code is the same as for example 1, but we have added a
+> `REPOBEE-SANITIZER-REPLACE-WITH` marker.
 
-As we can see in Example 2, this lets us provide two versions of a function, one that is current, and one that will replace it. Example 1 and 2 shows us a piece of code used in the KTH course DD1338. This code is part of an assignment where students are asked to implement a test function. The example shows a finished solution that is availiable to the teachers of the course. However, because of `repobee-sanitizer` and the `REPLACE-WITH` marker, the code can be reduced to the following:
+As we can see in Example 2, this lets us provide two versions of a function,
+one that is current, and one that will replace it. Example 1 and 2 shows us a
+piece of code used in the KTH course DD1338. This code is part of an assignment
+where students are asked to implement a test function. The example shows a
+finished solution that is availiable to the teachers of the course. However,
+because of `repobee-sanitizer` and the `REPLACE-WITH` marker, the code can be
+reduced to the following:
 
-````java
+```java
 class StackTest {
     @Test
     public void topIsLastPushedValue() {
         fail("Not implemented");
     }
 }
-````
+```
 
 > Example 3: Sanitized code that is provided to students.
 
-We can see that the only code that remains inside the function is that of the `REPLACE-WITH` marker. This gives us the main usage that `repobee-santizer` was developed for, it allows us to combine finished solutions with the "skeletonized" solutions that are provided to students.
+We can see that the only code that remains inside the function is that of the
+`REPLACE-WITH` marker. This gives us the main usage that `repobee-santizer` was
+developed for, it allows us to combine finished solutions with the
+"skeletonized" solutions that are provided to students.
 
-# Prefixing
+## Prefixing
 
-Sometimes (usually) we want code that can run, its a good thing then that `repobee-sanitizer` blocks can be commented out! Example 2 will produce the same output as the following:
+Sometimes (usually) we want code that can run, its a good thing then that
+`repobee-sanitizer` blocks can be commented out! Example 2 will produce the
+same output as the following:
 
-````java
+```java
 class StackTest {
     @Test
     public void topIsLastPushedValue() {
@@ -121,28 +142,35 @@ class StackTest {
 //REPOBEE-SANITIZER-END
     }
 }
-````
+```
 
 > Example 4: Java code with `repobee-sanitizer` related syntax commented out
 
-`repobee-sanitizer` automatically detects if there is a prefix in front of any markers. This way we can have java comments: `//`, python comments: `#` or similar preceding our markers. **This means code can still compile!**
+`repobee-sanitizer` automatically detects if there is a prefix in front of any
+markers. This way we can have java comments: `//`, python comments: `#` or
+similar preceding our markers. **This means code can still compile!**
 
-## Some rules for prefixing:
+### Some rules for prefixing:
 
 `repobee-sanitizer`:
 
 * Determines prefix as any text that comes before `REPOBEE-SANITIZER-START`
-* Only determines prefix on a block-to-block basis, meaning that the prefix selected at a `BLOCK` marker must be used untill and including the next `END` marker
-  * This means that all `repobee-sanitizer` blocks can have individuall prefixes
+* Only determines prefix on a block-to-block basis, meaning that the prefix
+  selected at a `BLOCK` marker must be used untill and including the next `END`
+  marker
+  * This means that all `repobee-sanitizer` blocks can have individuall
+    prefixes
 * Code between replace and end markers **MUST** also be prefixed
 
-# Syntax
+## Markup syntax
 
-for `repobee-sanitizer` to work, marker syntax must be correct, this includes spelling of the markers themselves, the markers currently are as follows:
+for `repobee-sanitizer` to work, markup syntax must be correct, this includes
+spelling of the markers themselves, the markers currently are as follows:
 
 - REPOBEE-SANITIZER-START
     - REQUIRED: A block is not a block without a start marker
-    - Indicates the start of a block. Any text will be removed untill reaching a `REPLACE-WITH` or `END` marker.
+    - Indicates the start of a block. Any text will be removed untill reaching
+      a `REPLACE-WITH` or `END` marker.
 - REPOBEE-SANITIZER-REPLACE-WITH
     - OPTIONAL: but requires a start and end block.
     - Any text between this marker and the next `END` marker will remain.
@@ -150,11 +178,13 @@ for `repobee-sanitizer` to work, marker syntax must be correct, this includes sp
     - REQUIRED: Must exist for each start block
     - Indicates the end of a block.
 - REPOBEE_SANITIZER-SHRED
-    - OPTIONAL: Can only exist on the first line of a file. If this exists, there cannot be any other markers of any type in the file
-    - Having this marker will remove the entire file when running the `sanitize-repo` or `sanitize-file` commands
+    - OPTIONAL: Can only exist on the first line of a file. If this exists,
+      there cannot be any other markers of any type in the file
+    - Having this marker will remove the entire file when running the
+      `sanitize-repo` or `sanitize-file` commands
 
 If a marker is incorrectly spelled, `repobee-sanitizer` will report an error.
 
-# License
+## License
 
 See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
There's a bunch of odd formatting in the README. This PR fixes the following.

* Wrap lines at 80 characters
* Fix code blocks enclosed by too many backticks
* Fix heading sizes to align with other RepoBee documentation (only first heading is an h1, rest h2 and smaller)