### PR TITLE
[misc] Set checkout fetch-depth to 2

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
This should fix Codecov not always reporting the coverage. It complains about having too shallow fetch depth: https://github.com/repobee/repobee-sanitizer/runs/1962911284?check_suite_focus=true#step:9:25